### PR TITLE
fix: use absolute URLs for Open Graph images

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
     siteName: 'Venta de Garage',
     images: [
       {
-        url: '/og.png',
+        url: 'https://estebanybiankavendensustiliches.com/og.png',
         width: 1200,
         height: 630,
         alt: 'Venta de Garage - Esteban y Bianka venden sus tiliches',
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: "Venta de Garage",
     description: "Productos únicos de segunda mano, en buen estado y a excelentes precios.",
-    images: ['/og.png'],
+    images: ['https://estebanybiankavendensustiliches.com/og.png'],
   },
   icons: {
     icon: '/favicon.svg',


### PR DESCRIPTION
- Change og:image from relative to absolute URL for better social platform compatibility
- Some platforms (including WhatsApp) require absolute URLs for preview images